### PR TITLE
Fixed custom deleter circular dependency with event dispatcher

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -80,6 +80,12 @@
         "typeindex": "cpp",
         "typeinfo": "cpp",
         "valarray": "cpp",
-        "variant": "cpp"
+        "variant": "cpp",
+        "coroutine": "cpp",
+        "hash_map": "cpp",
+        "hash_set": "cpp",
+        "shared_mutex": "cpp",
+        "cfenv": "cpp",
+        "*.rh": "cpp"
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,6 +60,4 @@ int main (int args, char* argv[])
 
 	GameInstance::InitGameInstance(WindowProperties(1280, 720, 60, false, isDebug));
 	
-	CloseWindow();
-	return 0;
 }

--- a/src/private/Base/BaseUI.cpp
+++ b/src/private/Base/BaseUI.cpp
@@ -1,1 +1,6 @@
 #include "Base/BaseUI.h"
+
+void BaseUI::MarkForDestruction() 
+{
+    Super::MarkForDestruction();
+}

--- a/src/private/Base/Entity.cpp
+++ b/src/private/Base/Entity.cpp
@@ -24,5 +24,29 @@ void Entity::MoveEntityToPosition(Vector2 TargetPosition)
 		AngleDeg += 360.0f;
 	}
 
-	this->m_DesiredCourse = ((int)AngleDeg % 360);
+	this->SetCourse(((int)AngleDeg % 360));
+}
+void Entity::SetSpeed(NavalUnits::Knot DesiredKnots)
+{
+	#if DEBUG
+	LOG_INFO(l_GAMEMODE, TEXT("Setting Desired Speed to {}", static_cast<int>(DesiredKnots)));
+	#endif
+	m_DesiredKnots = DesiredKnots;
+}
+
+void Entity::SetInitialSpeed(NavalUnits::Knot DesiredKnots)
+{
+	#if DEBUG
+	LOG_INFO(l_GAMEMODE, TEXT("Setting Initial Speed to {}", static_cast<int>(DesiredKnots)));
+	#endif
+	m_DesiredKnots = DesiredKnots;
+    m_CurrentKnots = DesiredKnots;
+}
+
+void Entity::SetCourse(int Course)
+{
+	#if DEBUG
+	LOG_INFO(l_GAMEMODE, TEXT("Setting Course To: {}", Course));
+	#endif
+	m_DesiredCourse = Course % 360;
 }

--- a/src/private/Base/EventDispatcher.cpp
+++ b/src/private/Base/EventDispatcher.cpp
@@ -26,6 +26,19 @@ bool EventDispatcher::RemoveListener(const std::string& Identifier, SClass* Even
 	return true;
 }
 
+void EventDispatcher::DumpListeners() const
+{
+	LOG_INFO(l_DISPATCHER, TEXT("=== EventDispatcher '{}' Listeners ===", m_Name));
+    for (const auto& [eventClass, listeners] : m_Listener)
+    {
+        LOG_INFO(l_DISPATCHER, TEXT("  EventClass '{}': {} listeners", 
+            eventClass->ClassName, listeners.size()));
+        for (const auto& [id, callback] : listeners)
+        {
+            LOG_INFO(l_DISPATCHER, TEXT("    - '{}'", id));
+        }
+    }
+}
 
 void EventDispatcher::Dispatch(std::shared_ptr<IEvent> EventToDispatch, const std::string& Identifier, bool bUseIdentifier)
 {

--- a/src/private/Base/GameInstance.cpp
+++ b/src/private/Base/GameInstance.cpp
@@ -36,10 +36,6 @@
 #include "Base/EventData.hpp"
 #include "Events/WindowResizeData.hpp"
 
-			#include <unistd.h>
-			#include <fstream>
-			#include <string>
-
 // Definition of the static member
 EventDispatcher GameInstance::UIEventDispatcher;
 EventDispatcher GameInstance::SaveStateDispatcher;
@@ -228,7 +224,6 @@ void GameInstance::GameLoop()
 		BeginDrawing();
 		if (g_ActiveStateMachine.isPendingKillLastMode())
 		{
-			// Print the size of the GameInstance object (not total memory usage)
 			g_ActiveStateMachine.KillLastGameMode();
 		}
 		g_ActiveStateMachine.UpdateGameMode();

--- a/src/private/Base/GameInstance.cpp
+++ b/src/private/Base/GameInstance.cpp
@@ -36,6 +36,10 @@
 #include "Base/EventData.hpp"
 #include "Events/WindowResizeData.hpp"
 
+			#include <unistd.h>
+			#include <fstream>
+			#include <string>
+
 // Definition of the static member
 EventDispatcher GameInstance::UIEventDispatcher;
 EventDispatcher GameInstance::SaveStateDispatcher;
@@ -224,6 +228,7 @@ void GameInstance::GameLoop()
 		BeginDrawing();
 		if (g_ActiveStateMachine.isPendingKillLastMode())
 		{
+			// Print the size of the GameInstance object (not total memory usage)
 			g_ActiveStateMachine.KillLastGameMode();
 		}
 		g_ActiveStateMachine.UpdateGameMode();

--- a/src/private/Base/GameInstance.cpp
+++ b/src/private/Base/GameInstance.cpp
@@ -252,5 +252,33 @@ void GameInstance::GameLoop()
 		DrawText((std::string("Version: ") + Version).c_str(), 0 + 5, GetScreenHeight() - 20, 12, WHITE);
 		EndDrawing();
 	}
+
+GameInstance::GetInstance()->GetCurrentGameMode()->~GameMode();
+
+LOG_INFO(l_GAME_INSTANCE, "Starting shutdown sequence...");
+
+LOG_INFO(l_GAME_INSTANCE, "Waiting for resource cleanup threads...");
+for (auto& [name, resource] : g_ResourceManager.AllResources)
+{
+    resource.ForceCleanup();
+}
+
+LOG_INFO(l_GAME_INSTANCE, "Processing pending tasks...");
+MainQueue.ProcessTasks();
+
+g_ResourceManager.AllResources.clear();
+LOG_INFO(l_GAME_INSTANCE, "Resources cleared");
+
+LOG_INFO(l_GAME_INSTANCE, "Closing audio and window...");
+
+SetTraceLogCallback(nullptr);
+
+CloseAudioDevice();
+CloseWindow();
+
+LOG_INFO(l_GAME_INSTANCE, "GameInstance shutdown complete");
+
+spdlog::shutdown();
+
 }
 

--- a/src/private/Base/GameMode.cpp
+++ b/src/private/Base/GameMode.cpp
@@ -19,6 +19,11 @@ GameMode::~GameMode()
 	// Clear objects map - this will trigger shared_ptr destructors
 	// but UnregisterObject calls will be ignored due to m_IsDestroying flag
 	    // Remove all event listeners FIRST to break the circular reference
+	for (auto& obj : m_Objects)
+	{
+		obj.second->MarkForDestruction();
+	}
+
 	m_Objects.clear();
 	m_PendingKill.clear();
 	#if DEBUG

--- a/src/private/Base/GameMode.cpp
+++ b/src/private/Base/GameMode.cpp
@@ -1,5 +1,6 @@
 #include "Base/GameMode.h"
 #include "Base/Factory.hpp"
+#include "Base/Core.h"
 
 GameMode::GameMode()
 {
@@ -8,13 +9,23 @@ GameMode::GameMode()
 
 GameMode::~GameMode()
 {
+	#if DEBUG
+	LogInfo(l_GAMEMODE, TEXT("Start Destructor of GameMode: {}", this->m_Name));
+	LogInfo(l_GAMEMODE, TEXT("{} Objects belong to GameMode before Cleaning", this->m_Objects.size()));
+	#endif
 	// Set flag to prevent UnregisterObject calls during destruction
 	m_IsDestroying = true;
 	
 	// Clear objects map - this will trigger shared_ptr destructors
 	// but UnregisterObject calls will be ignored due to m_IsDestroying flag
+	    // Remove all event listeners FIRST to break the circular reference
 	m_Objects.clear();
 	m_PendingKill.clear();
+	#if DEBUG
+	LogInfo(l_GAMEMODE, TEXT("Finished Destructor of GameMode: {}", this->m_Name));
+	LogInfo(l_GAMEMODE, TEXT("{} Objects belong to GameMode after Cleaning", this->m_Objects.size()));
+
+	#endif
 }
 
 
@@ -83,7 +94,6 @@ void GameMode::RegisterObject(std::shared_ptr<IObject> Object)
 
 void GameMode::UnregisterObject(IObject* inObject)
 {
-	// Skip unregistration if GameMode is being destroyed to prevent circular destruction
 	if (m_IsDestroying) {
 		return;
 	}

--- a/src/private/Base/Object.cpp
+++ b/src/private/Base/Object.cpp
@@ -2,7 +2,7 @@
 #include "Base/GameInstance.h"
 #include "Base/GameMode.h"
 #include "Events/KeyEvent.hpp"
-
+#include "Events/MouseEvent.hpp"
 
 GameMode* IObject::GetOutter()
 {
@@ -26,5 +26,3 @@ Object::Object()
 {
 
 }
-
-

--- a/src/private/Base/ResourceManager.cpp
+++ b/src/private/Base/ResourceManager.cpp
@@ -135,7 +135,7 @@ void TextureResource::RemoveRef()
                 auto CurrentTime = StartTime;
                 bool StillZero = true;
                 size_t ResetCounter = 0;
-                while (StartTime + std::chrono::seconds(120) > CurrentTime)
+                while (StartTime + std::chrono::seconds(120) > CurrentTime && !ShutdownRequested.load())
                 {
                     std::this_thread::sleep_for(std::chrono::seconds(5));
                     CurrentTime = std::chrono::system_clock::now();
@@ -178,6 +178,18 @@ void TextureResource::RemoveRef()
                 WorkerDone.store(true);
                 return;
             });
+    }
+}
+
+void TextureResource::ForceCleanup()
+{
+    ShutdownRequested.store(true);
+    if (WorkerFuture.valid() == false) // No GC in action
+    {
+        GameInstance::GetInstance()->MainQueue.Enqueue([this]()
+        {
+            this->UnloadTexture();
+        });
     }
 }
 

--- a/src/private/Entities/BaseSubmarine.cpp
+++ b/src/private/Entities/BaseSubmarine.cpp
@@ -10,23 +10,6 @@ void BaseSubmarine::Tick(float DeltaTime)
     Accel(DeltaTime);
 }
 
-void BaseSubmarine::SetSpeed(NavalUnits::Knot DesiredKnots)
-{
-    m_DesiredKnots = DesiredKnots;
-}
-
-void BaseSubmarine::SetInitialSpeed(NavalUnits::Knot DesiredKnots)
-{
-    m_DesiredKnots = DesiredKnots;
-    m_CurrentKnots = DesiredKnots;
-}
-
-void BaseSubmarine::SetCourse(int Course)
-{
-    std::cout << "Course is now: " << Course << std::endl;
-    m_DesiredCourse = Course % 360;
-}
-
 void BaseSubmarine::CalculateSpeed(float Deltatime)
 {
     m_SpeedChangeTimer += Deltatime;

--- a/src/private/GameModes/SandboxGameMode.cpp
+++ b/src/private/GameModes/SandboxGameMode.cpp
@@ -54,14 +54,12 @@ void SandboxGameMode::BeginPlay()
 
 }
 
-SandboxGameMode::~SandboxGameMode()
-{
-}
-
 void SandboxGameMode::Update()
 {
 		ClearBackground(BLACK);
 		GameMode::Update();
+
+
 
 		DrawFocusPlayer();
 
@@ -69,7 +67,10 @@ void SandboxGameMode::Update()
 #if DEBUG
 		DrawFPS(GameInstance::GetInstance()->GetWindowProperties().m_ScreenWidth - 100, 20);
 #endif
-
+		if (IsKeyPressed(KEY_K))
+		{
+			GameInstance::GetInstance()->g_ActiveStateMachine.ChangeState("Menu");
+		}
 }
 
 void SandboxGameMode::SetName(std::string Name)

--- a/src/private/GameModes/SandboxGameMode.cpp
+++ b/src/private/GameModes/SandboxGameMode.cpp
@@ -54,6 +54,7 @@ void SandboxGameMode::BeginPlay()
 
 }
 
+
 void SandboxGameMode::Update()
 {
 		ClearBackground(BLACK);

--- a/src/private/GameModes/SandboxGameMode.cpp
+++ b/src/private/GameModes/SandboxGameMode.cpp
@@ -54,7 +54,6 @@ void SandboxGameMode::BeginPlay()
 
 }
 
-
 void SandboxGameMode::Update()
 {
 		ClearBackground(BLACK);

--- a/src/private/StateMachines/GameModeSwitcher.cpp
+++ b/src/private/StateMachines/GameModeSwitcher.cpp
@@ -1,5 +1,7 @@
 #include "StateMachines/GameModeSwitcher.h"
 #include "Base/GameMode.h"
+#include "Events/KeyEvent.hpp"
+#include "Events/MouseEvent.hpp"
 
 void GameModeSwitcher::RegisterState(const std::string& StateName, std::function<GameMode* ()> FactoryFunction)
 {
@@ -8,7 +10,9 @@ void GameModeSwitcher::RegisterState(const std::string& StateName, std::function
 
 void GameModeSwitcher::ChangeState(const std::string& StateName)
 {
+	LOG_INFO(l_GAMEMODE, TEXT("============================================="));
 	LOG_INFO(l_GAMEMODE, TEXT("GameMode: '{}' Requested Loading", StateName));
+	LOG_INFO(l_GAMEMODE, TEXT("============================================="));
 	if (CurrentGameMode != nullptr)
 	{
 		LastGameMode = CurrentGameMode;
@@ -20,25 +24,29 @@ void GameModeSwitcher::ChangeState(const std::string& StateName)
 
 	CurrentGameMode = StateFactory[StateName]();
 	CurrentGameMode->BeginPlay();
+	LOG_INFO(l_GAMEMODE, TEXT("============================================="));
 	LOG_INFO(l_GAMEMODE, TEXT("GameMode: '{}' Successfully Loaded and 'BeginPlay()' called", StateName));
+	LOG_INFO(l_GAMEMODE, TEXT("============================================="));
 
 }
 
 void GameModeSwitcher::KillLastGameMode()
 {
-	if (LastGameMode)
-	{
-		std::string LastName = LastGameMode->GetName();
-		delete LastGameMode;
-		LastGameMode = nullptr;
-		if (LastGameMode == nullptr)
-		{
-			bPendingKillLastMode = false;
 
-			LOG_INFO(l_GAMEMODE, TEXT("Old GameMode: '{}' Deleted", LastName));
-
-		}
-	}
+    if (LastGameMode)
+    {
+        std::string LastName = LastGameMode->GetName();
+        LOG_INFO(l_DISPATCHER, TEXT("=== Before deleting GameMode '{}' ===", LastName));
+        
+        delete LastGameMode;
+        LastGameMode = nullptr;
+        
+        if (LastGameMode == nullptr)
+        {
+            bPendingKillLastMode = false;
+            LOG_INFO(l_GAMEMODE, TEXT("Old GameMode: '{}' Deleted", LastName));
+        }
+    }
 }
 
 void GameModeSwitcher::UpdateGameMode() const

--- a/src/private/UI/Display.cpp
+++ b/src/private/UI/Display.cpp
@@ -19,6 +19,11 @@ void Display::Draw()
 	EndTextureMode();
 }
 
+void Display::MarkForDestruction()
+{
+	Super::MarkForDestruction();
+}
+
 void Display::SetPosition(Vector2 NewPosition)
 {
 	DestinationRect.x = NewPosition.x;

--- a/src/private/UI/Map.cpp
+++ b/src/private/UI/Map.cpp
@@ -32,11 +32,13 @@ Map::Map(int X, int Y)
 
 Map::~Map()
 {
-    unsigned int vaos[] = { vaoAfrica, vaoEurope, vaoAsia, vaoNA, vaoOceania, vaoSA, vaoAntarctica };
-    unsigned int vbos[] = { vboAfrica, vboEurope, vboAsia, vboNA, vboOceania, vboSA, vboAntarctica };
-    glDeleteVertexArrays(7, vaos);
-    glDeleteBuffers(7, vbos);
-
+    unsigned int vaos[] = { vaoAfrica, vaoEurope, vaoAsia, vaoNA, vaoOceania, vaoSA, vaoAntarctica, vaoSevenSeas };
+    unsigned int vbos[] = { vboAfrica, vboEurope, vboAsia, vboNA, vboOceania, vboSA, vboAntarctica, vboSevenSeas };
+    glDeleteVertexArrays(8, vaos);
+    glDeleteBuffers(8, vbos);
+    UnloadTexture(PlayerIcon);
+    UnloadTexture(ShipIcon);
+    UnloadShader(shader);
     Display::~Display();
 }
 
@@ -303,35 +305,35 @@ void Map::Init()
     FullSpeedEntry.SetDisplayName("Full Speed");
     FullSpeedEntry.SetCallback([this](ContextMenuEntry* Self)
         {
-            TrackedPlayer->SetSpeed(20);
+            TrackedPlayer.lock()->SetSpeed(20);
         });
 
     ContextMenuEntry HalfSpeedEntry;
     HalfSpeedEntry.SetDisplayName("Half Speed");
     HalfSpeedEntry.SetCallback([this](ContextMenuEntry* Self)
         {
-            TrackedPlayer->SetSpeed(12);
+            TrackedPlayer.lock()->SetSpeed(12);
         });
 
     ContextMenuEntry SlowAheadEntry;
     SlowAheadEntry.SetDisplayName("Slow Ahead");
     SlowAheadEntry.SetCallback([this](ContextMenuEntry* Self)
         {
-            TrackedPlayer->SetSpeed(8);
+            TrackedPlayer.lock()->SetSpeed(8);
         });
 
     ContextMenuEntry DeadSlowEntry;
     DeadSlowEntry.SetDisplayName("Dead Slow");
     DeadSlowEntry.SetCallback([this](ContextMenuEntry* Self)
         {
-            TrackedPlayer->SetSpeed(3);
+            TrackedPlayer.lock()->SetSpeed(3);
         });
 
     ContextMenuEntry StopEntry;
     StopEntry.SetDisplayName("Stop");
     StopEntry.SetCallback([this](ContextMenuEntry* Self)
         {
-            TrackedPlayer->SetSpeed(0);
+            TrackedPlayer.lock()->SetSpeed(0);
         });
 
     SpeedMenu.TryLoad()->AddMenuEntry(FullSpeedEntry);
@@ -346,7 +348,7 @@ void Map::Init()
     NewEntry.SetDisplayName("Center Player");
     NewEntry.SetCallback([this](ContextMenuEntry* Self) -> void
         {
-            CameraWorldPosition = TrackedPlayer->GetEntityLocation();
+            CameraWorldPosition = TrackedPlayer.lock()->GetEntityLocation();
             return;
         });
 
@@ -360,7 +362,7 @@ void Map::Init()
 
             MarkedPos = MousePos;
 
-            TrackedPlayer->MoveEntityToPosition(MarkedPos);
+            TrackedPlayer.lock()->MoveEntityToPosition(MarkedPos);
 
         });
 
@@ -393,12 +395,12 @@ void Map::AddObjectToDraw(std::weak_ptr<IObject> inObject)
     if (inObject.lock() != nullptr && *inObject.lock()->GetStaticClass() << (Entity::StaticClass()))
     {
         std::cout << "Found Derived " << inObject.lock()->GetDisplayName() << std::endl;
-        std::shared_ptr<Player> PlayerPTR = nullptr;
+        std::weak_ptr<Player> PlayerPTR;
         if (*(inObject.lock()->GetStaticClass()) << (Player::StaticClass()))
         {
             PlayerPTR = std::dynamic_pointer_cast<Player>(inObject.lock());
         }
-        if (PlayerPTR && TrackedPlayer == nullptr)
+        if (PlayerPTR.lock() && TrackedPlayer.lock() == nullptr)
         {
             TrackedPlayer = PlayerPTR;
             auto EntityPtr = std::dynamic_pointer_cast<Entity>(inObject.lock());
@@ -418,7 +420,7 @@ void Map::OnKeyStroke(KeyboardKey Key, Vector2 MousePos)
     if (CheckCollisionPointRec(MousePos, DestinationRect)
         && Key == KEY_C)
     {
-        CameraWorldPosition = TrackedPlayer->GetEntityLocation();
+        CameraWorldPosition = TrackedPlayer.lock()->GetEntityLocation();
         ZoomLevel = 1.f;
     }
 }

--- a/src/private/UI/WaterfallDisplay.cpp
+++ b/src/private/UI/WaterfallDisplay.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include "omp.h"
 
+
 Waterfall::Waterfall(int Width, int Height, int TimeFrame)
     : Display(Width, Height), WorkerDone(true), RenderReady(false), TimeFrameInSec(TimeFrame)
 {
@@ -23,6 +24,8 @@ Waterfall::Waterfall(int Width, int Height, int TimeFrame)
         FrontBuffer->m_Width, 
         FrontBuffer->m_Height, 
         Size));
+
+    InDestruction.store(false);
 }
 
 Waterfall::~Waterfall() 
@@ -46,6 +49,11 @@ void Waterfall::Tick(float DeltaTime)
 
     // change to always accumulate data and process them, no matter how many lines we shift
     // but reset the sampled data when we shift
+
+    if (InDestruction.load())
+    {
+        return;
+    }
 
     // Temp to change index of signal
     if (IsKeyDown(KEY_A))
@@ -147,6 +155,19 @@ void Waterfall::Draw()
     DrawTexture(FrontTexture, 0, 0, WHITE);
     GenerateBearings();
     EndTextureMode();
+}
+
+void Waterfall::MarkForDestruction()
+{
+    InDestruction.store(true);
+
+    if (WorkerFuture.valid())
+    {
+        WorkerFuture.wait();
+    }
+
+    LogInfo(l_HOUSE_KEEPING, TEXT("Cleaned Up Waterfall now Calling: {}", Super::GetStaticClass()->ClassName));
+    Super::MarkForDestruction();
 }
 
 float Waterfall::TimestepPerPixel()

--- a/src/public/Base/BaseUI.h
+++ b/src/public/Base/BaseUI.h
@@ -10,6 +10,7 @@ public:
 	// Methods
 
 	BaseUI() = default;
+	virtual void MarkForDestruction() override;
 	virtual ~BaseUI() = default;
 
 

--- a/src/public/Base/Core.h
+++ b/src/public/Base/Core.h
@@ -84,6 +84,7 @@ void InitLogger();
 private: \
 	static inline SClass m_SClass = SClass(Parent::StaticClass(), #Base); \
 public: \
+    using Super = Parent; \
     virtual SClass* GetStaticClass() override { return &m_SClass; } \
     static SClass* StaticClass() { return  &m_SClass; } \
 private:

--- a/src/public/Base/Entity.hpp
+++ b/src/public/Base/Entity.hpp
@@ -29,6 +29,10 @@ public:
 
 	void MoveEntityToPosition(Vector2 TargetPosition);
 
+	virtual void SetSpeed(NavalUnits::Knot DesiredKnots);
+	virtual void SetInitialSpeed(NavalUnits::Knot DesiredKnots);
+	virtual void SetCourse(int Course);
+
 
 	void SetAccelerationRate(float NewAccelRate) { m_AccelerationRate = NewAccelRate; }
 	void SetDampeningRate(float NewDampeningRate) { m_DampeningRate = NewDampeningRate; }

--- a/src/public/Base/EventDispatcher.hpp
+++ b/src/public/Base/EventDispatcher.hpp
@@ -26,6 +26,8 @@ public:
 	int AmountOfListener(std::shared_ptr<IEvent> EventToDispatch);
 	int AmountOfListener(SClass* ClassID);
 
+	void DumpListeners() const;
+
 	std::string m_Name;
 
 private:

--- a/src/public/Base/Factory.hpp
+++ b/src/public/Base/Factory.hpp
@@ -23,75 +23,74 @@
 class Factory
 {
 public:
+	Factory(GameMode *Outter)
+		: m_Outter(Outter)
+	{
+	}
 
-	Factory(GameMode* Outter)
-		:m_Outter(Outter)
-	{}
+	GameMode *m_Outter = nullptr;
 
-	GameMode* m_Outter = nullptr;
-
-	template<typename T, typename... Args>
-	SoftObjectPath<T> NewObject(Args&&... args)
+	template <typename T, typename... Args>
+	SoftObjectPath<T> NewObject(Args &&...args)
 	{
 		static_assert(std::is_base_of_v<IObject, T>,
-			"T must inherit from IObject");
+					  "T must inherit from IObject");
 
 		// SharedPtr with custom Deleter
 		auto Obj = std::shared_ptr<T>(
-				new T(std::forward<Args>(args)...),
-				// Custom Deleter to clean it from the Asset Registry and also from the GameMode
-				[Outter = m_Outter](T* ptr) 
-				{
-					LOG_INFO(l_FACTORY, TEXT("Cleaned Up Object: '{}'", ptr->m_Name));
-					GameInstance::KeyDispatcher.RemoveListener(ptr->m_Name, KeyEvent::StaticClass());
-					GameInstance::MouseDispatcher.RemoveListener(ptr->m_Name, MouseEvent::StaticClass());
+			new T(std::forward<Args>(args)...),
+			// Custom Deleter to clean it from the Asset Registry and also from the GameMode
+			[Outter = m_Outter](T *ptr)
+			{
+				std::cout << "WE DELETE SOMETHING" << std::endl;
+				std::cout.flush();
+				LOG_INFO(l_FACTORY, TEXT("Cleaned Up Object: '{}'", ptr->m_Name));
+				GameInstance::KeyDispatcher.RemoveListener(ptr->m_Name, KeyEvent::StaticClass());
+				GameInstance::MouseDispatcher.RemoveListener(ptr->m_Name, MouseEvent::StaticClass());
 
-					Outter->UnregisterObject(ptr);
-					GameInstance::GetAssetRegistry()->UnregisterAsset(ptr->m_Name);
-					delete ptr;
-				});
-
-
-		LOG_INFO(l_FACTORY, TEXT("Created Object from Type '{}' with size: '{}' and Registred to Outter: '{}'", typeid(T).name(), sizeof(T), m_Outter->GetName()));
+				Outter->UnregisterObject(ptr);
+				GameInstance::GetAssetRegistry()->UnregisterAsset(ptr->m_Name);
+				delete ptr;
+			});
 
 		std::shared_ptr<IObject> CastedObj = std::dynamic_pointer_cast<IObject>(Obj); // Casting it to the actual Type
 		std::string ClassName = CastedObj->GetStaticClass()->ClassName;
 
-		// typeid.name returns a whitespace and we clean it and replaces it with a .
+		LOG_INFO(l_FACTORY, TEXT("Created Object from Type '{}' with size: '{}' and Registred to Outter: '{}'", ClassName, sizeof(T), m_Outter->GetName()));
+
 		std::replace(ClassName.begin(), ClassName.end(), ' ', '.');
 
-		// Creating a Unique Name in the Asset Registry here
 		std::string GeneralName = m_Outter->GetName() + "/" + ClassName;
 		CastedObj->m_Name = GameInstance::GetAssetRegistry()->RegisterAsset(GeneralName);
 
-		// Subscribing to the Key Event for all IObjects which are created via factory
+		std::weak_ptr<IObject> WeakObj = CastedObj; // Create weak_ptr BEFORE the lambdas
+
 		GameInstance::KeyDispatcher.AddListener(
 			CastedObj->m_Name,
 			KeyEvent::StaticClass(),
-			[CastedObj](std::shared_ptr<IEvent> evt) 
+			[WeakObj](std::shared_ptr<IEvent> evt)
 			{
-				auto CastedKeyEvent = std::dynamic_pointer_cast<KeyEvent>(evt);
-
-				CastedObj->OnKeyStroke(CastedKeyEvent->KeyPressed, CastedKeyEvent->MousePos);
-			}
-		);
+				if (auto CastedObj = WeakObj.lock()) // Try to get shared_ptr
+				{
+					auto CastedKeyEvent = std::dynamic_pointer_cast<KeyEvent>(evt);
+					CastedObj->OnKeyStroke(CastedKeyEvent->KeyPressed, CastedKeyEvent->MousePos);
+				}
+			});
 		LOG_INFO(l_FACTORY, TEXT("Class: '{}' subscribed to OnKeyEvent", CastedObj->m_Name));
-
 
 		GameInstance::MouseDispatcher.AddListener(
 			CastedObj->m_Name,
 			MouseEvent::StaticClass(),
-			[CastedObj](std::shared_ptr<IEvent> evt)
+			[WeakObj](std::shared_ptr<IEvent> evt) // Capture weak_ptr instead
 			{
-				auto CastedKeyEvent = std::dynamic_pointer_cast<MouseEvent>(evt);
-
-				CastedObj->OnMouseButtonPressed(CastedKeyEvent->KeyPressed, CastedKeyEvent->MousePos);
-			}
-		);
+				if (auto CastedObj = WeakObj.lock()) // Try to get shared_ptr
+				{
+					auto CastedKeyEvent = std::dynamic_pointer_cast<MouseEvent>(evt);
+					CastedObj->OnMouseButtonPressed(CastedKeyEvent->KeyPressed, CastedKeyEvent->MousePos);
+				}
+			});
 		LOG_INFO(l_FACTORY, TEXT("Class: '{}' subscribed to OnMouseEvent", CastedObj->m_Name));
 
-
-		// Registering the created Obj to the GameMode
 		m_Outter->RegisterObject(Obj);
 
 		// we just return a SoftObjectPath

--- a/src/public/Base/Factory.hpp
+++ b/src/public/Base/Factory.hpp
@@ -42,11 +42,10 @@ public:
 			// Custom Deleter to clean it from the Asset Registry and also from the GameMode
 			[Outter = m_Outter](T *ptr)
 			{
-				std::cout << "WE DELETE SOMETHING" << std::endl;
-				std::cout.flush();
-				LOG_INFO(l_FACTORY, TEXT("Cleaned Up Object: '{}'", ptr->m_Name));
+				LOG_INFO(l_FACTORY, TEXT("Cleaning Up Object: '{}'", ptr->m_Name));
 				GameInstance::KeyDispatcher.RemoveListener(ptr->m_Name, KeyEvent::StaticClass());
 				GameInstance::MouseDispatcher.RemoveListener(ptr->m_Name, MouseEvent::StaticClass());
+				LOG_INFO(l_FACTORY, TEXT("Object:'{}' Unsubscribed from 'OnMouseEvent' and 'OnKeyEvent' ", ptr->m_Name));
 
 				Outter->UnregisterObject(ptr);
 				GameInstance::GetAssetRegistry()->UnregisterAsset(ptr->m_Name);

--- a/src/public/Base/NavalTypedefs.h
+++ b/src/public/Base/NavalTypedefs.h
@@ -9,15 +9,19 @@ namespace NavalUnits
 
     using NauticalMile = float;
     using Knot = float;
+    using Hz = double;
+
+    // Sound frequency units
+    constexpr Hz KHz = 1000 * 1;
+    constexpr Hz MHz = 1000 * KHz;
 
     inline float NauticalMilesToMeters(NauticalMile nm)
     {
         return nm * 1852.0f;
     }
 
-    constexpr inline  float KnotToMetersPerSecond(Knot k)
+    constexpr inline float KnotToMetersPerSecond(Knot k)
     {
         return k * 0.514444f;
     }
 }
-

--- a/src/public/Base/ResourceManager.hpp
+++ b/src/public/Base/ResourceManager.hpp
@@ -69,6 +69,7 @@ struct TextureNPatchInfo
 struct TextureResource 
 {
     friend SharedTexture2D;
+    friend GameInstance;
 
     TextureResource()
         :WorkerDone(true)
@@ -150,6 +151,7 @@ private:
     Texture2D LoadedTexture = {};
     int RefCount = 0;
     std::atomic<bool> WorkerDone;
+    std::atomic<bool> ShutdownRequested{false};
     std::future<void> WorkerFuture;
 
     void AddRef()
@@ -158,7 +160,7 @@ private:
     }
 
     void RemoveRef();
-
+    void ForceCleanup();
     bool UnloadTexture();
 };
 

--- a/src/public/Entities/BaseSubmarine.hpp
+++ b/src/public/Entities/BaseSubmarine.hpp
@@ -8,9 +8,6 @@ class BaseSubmarine : public Entity
 
 public:
 	virtual void Tick(float DeltaTime) override;
-	virtual void SetSpeed(NavalUnits::Knot DesiredKnots);
-	virtual void SetInitialSpeed(NavalUnits::Knot DesiredKnots);
-	virtual void SetCourse(int Course);
 
 
 protected:

--- a/src/public/Events/SoundEvent.hpp
+++ b/src/public/Events/SoundEvent.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include "Base/Core.h"
+#include "Base/Event.hpp"
+#include "SoftObject.hpp"
+
+class SoundEvent : public Event
+{
+	AUTOBODY(SoundEvent, Event)
+
+public:
+
+	Vector2 SoundOrigin = {0,0};
+	NavalUnits::Hz SignalStrength = 0;
+	SoftObjectPath<Entity> Sender;
+};

--- a/src/public/GameModes/SandboxGameMode.hpp
+++ b/src/public/GameModes/SandboxGameMode.hpp
@@ -14,12 +14,11 @@ public:
 
 
 
-	void Update() override;
-	void SetName(std::string Name) override;
-	void BeginPlay() override;
+	virtual void Update() override;
+	virtual void SetName(std::string Name) override;
+	virtual void BeginPlay() override;
+
 	void OnMapClickedEvent(std::shared_ptr<IEvent> Event);
-
-
 
 	void DrawFocusPlayer();
 

--- a/src/public/GameModes/SandboxGameMode.hpp
+++ b/src/public/GameModes/SandboxGameMode.hpp
@@ -11,7 +11,6 @@ class SandboxGameMode : public GameMode
 {
 public:
 	SandboxGameMode();
-	~SandboxGameMode();
 
 
 

--- a/src/public/UI/Display.hpp
+++ b/src/public/UI/Display.hpp
@@ -11,6 +11,7 @@ public:
 
 
 	virtual void Draw();
+	virtual void  MarkForDestruction() override;
 
 	void SetPosition(Vector2 NewPosition);
 	void RenderToMainBuffer();

--- a/src/public/UI/Map.hpp
+++ b/src/public/UI/Map.hpp
@@ -32,6 +32,8 @@ enum class InteractionState
 };
 
 // World Units: 1 Unit 1 Meter
+// TODO: we need to refactor this here a lot since we allocate a lot of memory
+// and most of the stuff here could be somehow created and managed over the factory
 class Map : public Display
 {
 	AUTOBODY(Map, Display)
@@ -105,7 +107,7 @@ private:
 
 
 	std::vector<std::pair<std::weak_ptr<Entity>, std::pair<ObjectType, ObjectState>>> ObjectsToDraw;
-	std::shared_ptr<Player> TrackedPlayer = nullptr;
+	std::weak_ptr<Player> TrackedPlayer;
 
 	std::vector<size_t> IndicesPendingKill;
 	long double ZoomLevel = 1.f;

--- a/src/public/UI/WaterfallDisplay.hpp
+++ b/src/public/UI/WaterfallDisplay.hpp
@@ -103,6 +103,7 @@ public:
 
 	virtual void Tick(float Deltatime) override;
 	virtual void Draw() override;
+	virtual void MarkForDestruction() override;
 
 private:
 
@@ -115,6 +116,7 @@ private:
 	std::atomic<bool> RenderReady;
 	std::future<void> WorkerFuture;
 	std::vector<int> m_CurrentAmbientLevel;
+	std::atomic<bool> InDestruction;
 	bool FirstUpdate = true;
 
 	int TimeFrameInSec;


### PR DESCRIPTION
This PR with some QOL features mainly fixed the custom deleter circular dependency for the Shared PTR and the dispatcher

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sound event carrying origin, signal strength and sender
  * Introduced frequency units: Hz, KHz, MHz
  * K-key shortcut to return to the menu in sandbox mode

* **Refactor**
  * Consolidated speed/course setters and UI destruction hooks for clearer lifecycle handling
  * Tracked player references moved to non-owning handles for safer UI behavior
  * Improved resource shutdown/force-cleanup and added listener dump diagnostics for better cleanup and logging

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->